### PR TITLE
Seed initial cache

### DIFF
--- a/src/_router.jsx
+++ b/src/_router.jsx
@@ -47,11 +47,12 @@ function Router() {
   );
 }
 
-const cache = new Map()
+const initialCache = new Map();
 
 function ServerOutput({ url }) {
+  const [cache, setCache] = useState(initialCache);
   if (!cache.has(url)) {
-    cache.set(url,  createFromFetch(fetch(url)))
+    cache.set(url, createFromFetch(fetch(url)))
   }
   const lazyJsx = cache.get(url);
   return use(lazyJsx);


### PR DESCRIPTION
That's the fix for the problem we had earlier with infinite suspends. We _are_ supposed to keep cache in state (so we can later invalidate it). But the "initial" cache needs to be hoisted outside.