### PR TITLE
Add vertical window height resize option to dev tool

### DIFF
--- a/src/_router.jsx
+++ b/src/_router.jsx
@@ -1,4 +1,4 @@
-import { StrictMode, useEffect, useState, use, startTransition ,  useCallback, useRef } from "react";
+import { StrictMode, useEffect, useState, use, startTransition, useCallback, useRef } from "react";
 import { createRoot } from "react-dom/client";
 import { /* FOR FRAMEWORK DEVS */ createFromFetch } from "react-server-dom-webpack/client";
 import "../utils/refresh.client.js";
@@ -23,12 +23,12 @@ window.router = {
 }
 
 function Router() {
-  const [url, setUrl] = useState('/rsc' +  window.location.search);
+  const [url, setUrl] = useState('/rsc' + window.location.search);
 
   useEffect(() => {
     function handleNavigate() {
       startTransition(() => {
-        setUrl('/rsc' +  window.location.search)
+        setUrl('/rsc' + window.location.search)
       })
     }
     callbacks.push(handleNavigate)
@@ -57,8 +57,9 @@ function ServerOutput({ url }) {
   const lazyJsx = cache.get(url);
   return use(lazyJsx);
 }
- 
+
 // ----------- debugging panel ----
+
 
 function DevPanel({ url }) {
   const [content, setContent] = useState([]);
@@ -93,7 +94,7 @@ function DevPanel({ url }) {
   }, [url]);
 
   return (
-    <aside style={{ height :getDevtoolHeight(mouseMove)}} className="fixed bottom-0 left-0 right-0 bg-white rounded-2  overflow-y-scroll">
+    <aside style={{ height: getDevtoolHeight(mouseMove) }} className="fixed bottom-0 left-0 right-0 bg-white rounded-2  overflow-y-scroll">
       <div {...getResizeProps()} className="w-full h-0.5 bg-slate-300 cursor-row-resize select-none"></div>
       <h2 className="font-bold p-3">Dev panel</h2>
       <ul className="p-0 whitespace-pre-wrap">
@@ -110,15 +111,6 @@ function DevPanel({ url }) {
       </ul>
     </aside>
   );
-}
-
-function getDevtoolHeight (mouseMove){
-  return  mouseMove !== null ? `${window.innerHeight - mouseMove}px`  : '260px';
-}
-
-function getLocalStorageValue(position) {
-  const { localStorage } = window ?? {};
-  return Number(localStorage?.getItem(`simple-rfc-devtool-resize-${position}`)) ?? null;
 }
 
 function useWindowResize({ position }) {
@@ -171,4 +163,14 @@ function useWindowResize({ position }) {
     mouseMove,
     getResizeProps,
   };
+}
+
+
+function getDevtoolHeight(mouseMove) {
+  return mouseMove !== null ? `${window.innerHeight - mouseMove}px` : '260px';
+}
+
+function getLocalStorageValue(position) {
+  const { localStorage } = window ?? {};
+  return Number(localStorage?.getItem(`simple-rfc-devtool-resize-${position}`)) ?? null;
 }

--- a/src/_router.jsx
+++ b/src/_router.jsx
@@ -152,7 +152,7 @@ function useWindowResize({ position }) {
       window.addEventListener("mouseup", handleMouseUp);
     }
 
-    timeout = setTimeout(() => localStorage.setItem(`simple-rfc-devtool-resize-${position}`, String(mouseMove === null ? "" : mouseMove)), 700);
+    timeout = setTimeout(() => localStorage.setItem(`simple-rfc-devtool-resize-${position}`, String(mouseMove === null ? "" : mouseMove)), 200);
 
     return () => {
       window.removeEventListener("mousemove", handleMouseMove);

--- a/src/_router.jsx
+++ b/src/_router.jsx
@@ -65,7 +65,7 @@ function DevPanel({ url }) {
   const [content, setContent] = useState([]);
 
   const { mouseMove, getResizeProps } = useWindowResize({
-    position: 'vertical',
+    direction: 'vertical',
   });
 
   useEffect(() => {
@@ -115,11 +115,15 @@ function DevPanel({ url }) {
   );
 }
 
-const toLocalStorageKey = (position) => `simple-rfc-devtool-resize-${position}`;
+/** @typedef {'vertical' | 'horizontal'} Direction */
+
+const toLocalStorageKey = (/** @type {Direction} */ direction) => `simple-rfc-devtool-resize-${direction}`;
 const DEFAULT_HEIGHT = 260;
 
-function useWindowResize({ position }) {
-  const [mouseMove, setMouseMove] = useState(getInitialSize(position));
+/**
+ * @param {{ direction: Direction }} */
+function useWindowResize({ direction }) {
+  const [mouseMove, setMouseMove] = useState(getInitialSize(direction));
   const [isMouseDown, setIsMouseDown] = useState(false);
   const ref = useRef(null);
 
@@ -134,7 +138,7 @@ function useWindowResize({ position }) {
   const handleMouseMove = useCallback(
     (event) => {
       if (isMouseDown) {
-        setMouseMove(position === "vertical" ? event.pageY : event.pageX);
+        setMouseMove(direction === "vertical" ? event.pageY : event.pageX);
       }
     },
     [isMouseDown]
@@ -155,7 +159,7 @@ function useWindowResize({ position }) {
       window.addEventListener("mouseup", handleMouseUp);
     }
 
-    timeout = setTimeout(() => localStorage.setItem(toLocalStorageKey(position), String(mouseMove === null ? "" : mouseMove)), 200);
+    timeout = setTimeout(() => localStorage.setItem(toLocalStorageKey(direction), String(mouseMove === null ? "" : mouseMove)), 200);
 
     return () => {
       window.removeEventListener("mousemove", handleMouseMove);
@@ -175,7 +179,8 @@ function getDevtoolHeight(mouseMove) {
   return `${window.innerHeight - mouseMove}px`;
 }
 
-function getInitialSize(position) {
+/** @param {Direction} direction */
+function getInitialSize(direction) {
   const { localStorage } = window ?? {};
-  return Number(localStorage?.getItem(toLocalStorageKey(position)) ?? DEFAULT_HEIGHT);
+  return Number(localStorage?.getItem(toLocalStorageKey(direction)) ?? DEFAULT_HEIGHT);
 }

--- a/src/_router.jsx
+++ b/src/_router.jsx
@@ -115,8 +115,11 @@ function DevPanel({ url }) {
   );
 }
 
+const toLocalStorageKey = (position) => `simple-rfc-devtool-resize-${position}`;
+const DEFAULT_HEIGHT = 260;
+
 function useWindowResize({ position }) {
-  const [mouseMove, setMouseMove] = useState(getLocalStorageValue(position));
+  const [mouseMove, setMouseMove] = useState(getInitialSize(position));
   const [isMouseDown, setIsMouseDown] = useState(false);
   const ref = useRef(null);
 
@@ -152,7 +155,7 @@ function useWindowResize({ position }) {
       window.addEventListener("mouseup", handleMouseUp);
     }
 
-    timeout = setTimeout(() => localStorage.setItem(`simple-rfc-devtool-resize-${position}`, String(mouseMove === null ? "" : mouseMove)), 200);
+    timeout = setTimeout(() => localStorage.setItem(toLocalStorageKey(position), String(mouseMove === null ? "" : mouseMove)), 200);
 
     return () => {
       window.removeEventListener("mousemove", handleMouseMove);
@@ -169,10 +172,10 @@ function useWindowResize({ position }) {
 
 
 function getDevtoolHeight(mouseMove) {
-  return mouseMove !== null ? `${window.innerHeight - mouseMove}px` : '260px';
+  return `${window.innerHeight - mouseMove}px`;
 }
 
-function getLocalStorageValue(position) {
+function getInitialSize(position) {
   const { localStorage } = window ?? {};
-  return Number(localStorage?.getItem(`simple-rfc-devtool-resize-${position}`)) ?? null;
+  return Number(localStorage?.getItem(toLocalStorageKey(position)) ?? DEFAULT_HEIGHT);
 }

--- a/src/_router.jsx
+++ b/src/_router.jsx
@@ -95,8 +95,10 @@ function DevPanel({ url }) {
 
   return (
     <aside style={{ height: getDevtoolHeight(mouseMove) }} className="fixed bottom-0 left-0 right-0 bg-white rounded-2  overflow-y-scroll">
-      <div {...getResizeProps()} className="w-full h-0.5 bg-slate-300 cursor-row-resize select-none"></div>
-      <h2 className="font-bold p-3">Dev panel</h2>
+      <div {...getResizeProps()} className="w-full h-4 cursor-row-resize select-none">
+        <hr className="border-t-2" />
+      </div>
+      <h2 className="font-bold p-3 pt-0">Dev panel</h2>
       <ul className="p-0 whitespace-pre-wrap">
         {content.map((entry, idx) => (
           <div className={'px-3 py-1 ' + (idx === 0 ? 'bg-blue-100' : idx === 1 ? 'bg-green-100' : 'bg-orange-200')}>

--- a/src/_router.jsx
+++ b/src/_router.jsx
@@ -94,7 +94,7 @@ function DevPanel({ url }) {
 
   return (
     <aside style={{ height :getDevtoolHeight(mouseMove)}} className="fixed bottom-0 left-0 right-0 bg-white rounded-2  overflow-y-scroll">
-      <div {...getResizeProps()} className="w-full h-0.5 bg-slate-300 cursor-row-resize"></div>
+      <div {...getResizeProps()} className="w-full h-0.5 bg-slate-300 cursor-row-resize select-none"></div>
       <h2 className="font-bold p-3">Dev panel</h2>
       <ul className="p-0 whitespace-pre-wrap">
         {content.map((entry, idx) => (


### PR DESCRIPTION
Added a new feature to the developer tool that enables vertical window height resizing for improved debugging experience. The code has been modified for consistent functionality across browsers and devices, improving the development process's productivity and efficiency.

![ezgif com-optimize](https://user-images.githubusercontent.com/36256353/229090314-b9caf002-9d2a-4709-815e-b3abc2162af4.gif)
